### PR TITLE
feat: Upgradable Contract Registry

### DIFF
--- a/skillsync_app/contracts/registry/README.md
+++ b/skillsync_app/contracts/registry/README.md
@@ -1,0 +1,82 @@
+# Upgradable Contract Registry
+
+A Soroban smart contract that maps logical names to current contract addresses, enabling versioned upgrades (e.g., `escrow:v2`) while keeping a stable lookup interface for consumers.
+
+## Overview
+
+The registry stores a pointer from a `Symbol` name to a contract `Address`. An admin can update pointers, and consumers can resolve the active address by name.
+
+## Contract Interface
+
+### Entrypoints
+
+#### `init(admin: Address)`
+Initializes the contract with an admin address.
+
+#### `set(name: Symbol, addr: Address)`
+Admin-only update of a registry pointer. Emits `RegistryUpdated`.
+
+#### `get(name: Symbol) -> Address`
+Returns the current address for the name.
+
+#### `all() -> Vec<(Symbol, Address)>`
+Returns all registry entries in insertion order.
+
+#### `get_admin() -> Address`
+Returns the current admin address.
+
+## Storage
+
+- `Admin()` -> `Address` (instance storage)
+- `Registry(name)` -> `Address` (persistent storage)
+- `RegistryKeys()` -> `Vec<Symbol>` (instance storage)
+
+## Events
+
+### RegistryUpdated
+Emitted when a pointer is set or updated.
+- Topics: `("RegistryUpdated")`
+- Data: `{ name, addr }`
+
+## Usage Example
+
+```bash
+# Initialize
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  -- init \
+  --admin $ADMIN_ADDRESS
+
+# Set a pointer (admin)
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source admin \
+  -- set \
+  --name escrow_v2 \
+  --addr $ESCROW_V2_ADDRESS
+
+# Resolve a pointer
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  -- get \
+  --name escrow_v2
+```
+
+## Security Considerations
+
+- **Authorization**: Only the admin can update pointers.
+- **Deterministic reads**: Consumers resolve by name with no mutable side effects.
+
+## Building
+
+```bash
+cd skillsync_app
+cargo build --release --target wasm32-unknown-unknown -p registry
+```
+
+## Testing
+
+```bash
+cd skillsync_app
+cargo test -p registry
+```

--- a/skillsync_app/contracts/registry/cargo.toml
+++ b/skillsync_app/contracts/registry/cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "registry"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/skillsync_app/contracts/registry/src/lib.rs
+++ b/skillsync_app/contracts/registry/src/lib.rs
@@ -1,0 +1,115 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
+};
+
+mod test;
+
+const ADMIN_KEY: Symbol = symbol_short!("ADMIN");
+const REGISTRY_KEYS: Symbol = symbol_short!("RKEYS");
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Registry(Symbol),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RegistryUpdatedEvent {
+    pub name: Symbol,
+    pub addr: Address,
+}
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum RegistryError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    NotFound = 3,
+}
+
+#[contract]
+pub struct RegistryContract;
+
+#[contractimpl]
+impl RegistryContract {
+    /// Initialize the registry with an admin address.
+    pub fn init(env: Env, admin: Address) -> Result<(), RegistryError> {
+        if env.storage().instance().has(&ADMIN_KEY) {
+            return Err(RegistryError::AlreadyInitialized);
+        }
+
+        env.storage().instance().set(&ADMIN_KEY, &admin);
+        Ok(())
+    }
+
+    /// Set or update a registry pointer (admin-only).
+    pub fn set(env: Env, name: Symbol, addr: Address) -> Result<(), RegistryError> {
+        let admin = read_admin(&env)?;
+        admin.require_auth();
+
+        let key = DataKey::Registry(name.clone());
+        let is_new = !env.storage().persistent().has(&key);
+
+        env.storage().persistent().set(&key, &addr);
+
+        if is_new {
+            let mut keys = read_registry_keys(&env);
+            keys.push_back(name.clone());
+            env.storage().instance().set(&REGISTRY_KEYS, &keys);
+        }
+
+        env.events().publish(
+            (Symbol::new(&env, "RegistryUpdated"),),
+            RegistryUpdatedEvent { name, addr },
+        );
+
+        Ok(())
+    }
+
+    /// Get the address for a registry name.
+    pub fn get(env: Env, name: Symbol) -> Result<Address, RegistryError> {
+        let key = DataKey::Registry(name);
+        env.storage()
+            .persistent()
+            .get(&key)
+            .ok_or(RegistryError::NotFound)
+    }
+
+    /// Return all registry entries in insertion order.
+    pub fn all(env: Env) -> Vec<(Symbol, Address)> {
+        let keys = read_registry_keys(&env);
+        let mut entries = Vec::new(&env);
+
+        for name in keys.iter() {
+            let key = DataKey::Registry(name.clone());
+            if let Some(addr) = env.storage().persistent().get(&key) {
+                entries.push_back((name, addr));
+            }
+        }
+
+        entries
+    }
+
+    /// Get the current admin address.
+    pub fn get_admin(env: Env) -> Result<Address, RegistryError> {
+        read_admin(&env)
+    }
+}
+
+fn read_admin(env: &Env) -> Result<Address, RegistryError> {
+    env.storage()
+        .instance()
+        .get(&ADMIN_KEY)
+        .ok_or(RegistryError::NotInitialized)
+}
+
+fn read_registry_keys(env: &Env) -> Vec<Symbol> {
+    env.storage()
+        .instance()
+        .get(&REGISTRY_KEYS)
+        .unwrap_or(Vec::new(env))
+}

--- a/skillsync_app/contracts/registry/src/test.rs
+++ b/skillsync_app/contracts/registry/src/test.rs
@@ -1,0 +1,106 @@
+#![cfg(test)]
+
+extern crate std;
+
+use crate::{RegistryContract, RegistryContractClient, RegistryError};
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Symbol};
+
+fn create_registry_contract(env: &Env) -> RegistryContractClient<'_> {
+    let contract_id = env.register(RegistryContract, ());
+    RegistryContractClient::new(env, &contract_id)
+}
+
+#[test]
+fn test_set_and_get_pointer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let registry = create_registry_contract(&env);
+    registry.init(&admin).unwrap();
+
+    let name = Symbol::new(&env, "escrow_v2");
+    let addr = Address::generate(&env);
+
+    registry.set(&name, &addr).unwrap();
+
+    let stored = registry.get(&name).unwrap();
+    assert_eq!(stored, addr);
+}
+
+#[test]
+fn test_update_pointer_keeps_single_entry() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let registry = create_registry_contract(&env);
+    registry.init(&admin).unwrap();
+
+    let name = symbol_short!("escrow");
+    let addr_v1 = Address::generate(&env);
+    let addr_v2 = Address::generate(&env);
+
+    registry.set(&name, &addr_v1).unwrap();
+    registry.set(&name, &addr_v2).unwrap();
+
+    let stored = registry.get(&name).unwrap();
+    assert_eq!(stored, addr_v2);
+
+    let entries = registry.all();
+    assert_eq!(entries.len(), 1);
+    let entry = entries.get(0).unwrap();
+    assert_eq!(entry, (name, addr_v2));
+}
+
+#[test]
+fn test_all_returns_multiple_entries() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let registry = create_registry_contract(&env);
+    registry.init(&admin).unwrap();
+
+    let name1 = symbol_short!("escrow");
+    let addr1 = Address::generate(&env);
+    let name2 = symbol_short!("refund");
+    let addr2 = Address::generate(&env);
+
+    registry.set(&name1, &addr1).unwrap();
+    registry.set(&name2, &addr2).unwrap();
+
+    let entries = registry.all();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries.get(0).unwrap(), (name1, addr1));
+    assert_eq!(entries.get(1).unwrap(), (name2, addr2));
+}
+
+#[test]
+#[should_panic]
+fn test_set_requires_admin_auth() {
+    let env = Env::default();
+
+    let admin = Address::generate(&env);
+    let registry = create_registry_contract(&env);
+    registry.init(&admin).unwrap();
+
+    let name = symbol_short!("escrow");
+    let addr = Address::generate(&env);
+
+    registry.set(&name, &addr).unwrap();
+}
+
+#[test]
+fn test_get_missing_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let registry = create_registry_contract(&env);
+    registry.init(&admin).unwrap();
+
+    let name = symbol_short!("missing");
+    let result = registry.try_get(&name);
+    assert_eq!(result, Err(Ok(RegistryError::NotFound)));
+}


### PR DESCRIPTION
closes #24 

I have set up the upgradable contract registry as a new Soroban contract, with admin-only updates, pointer lookup, optional all() listing, events, tests, and a README. The contract stores admin in instance storage, registry entries in persistent storage, and keeps a key list for enumeration.