### PR TITLE
feat(core): add admin-configurable dispute window with bounds and update event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,10 +83,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base16ct"
@@ -232,6 +271,7 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 name = "core"
 version = "0.1.0"
 dependencies = [
+ "derive_arbitrary",
  "soroban-sdk",
 ]
 
@@ -281,6 +321,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -364,6 +414,17 @@ checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -550,6 +611,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "group"
@@ -756,6 +823,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +887,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -973,6 +1058,12 @@ dependencies = [
  "hmac",
  "subtle",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc_version"
@@ -1201,6 +1292,7 @@ version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c14e18d879c520ff82612eaae0590acaf6a7f3b977407e1abb1c9e31f94c7814"
 dependencies = [
+ "arbitrary",
  "crate-git-revision",
  "ethnum",
  "num-derive",
@@ -1228,6 +1320,7 @@ version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "114a0fa0d0cc39d0be16b1ee35b6e5f4ee0592ddcf459bde69391c02b03cf520"
 dependencies = [
+ "backtrace",
  "curve25519-dalek",
  "ed25519-dalek",
  "getrandom 0.2.11",
@@ -1283,7 +1376,10 @@ version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84fc8be9068dd4e0212d8b13ad61089ea87e69ac212c262914503a961c8dc3a3"
 dependencies = [
+ "arbitrary",
  "bytes-lit",
+ "ctor",
+ "ed25519-dalek",
  "rand",
  "serde",
  "serde_json",
@@ -1394,6 +1490,7 @@ version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e59cdf3eb4467fb5a4b00b52e7de6dca72f67fac6f9b700f55c95a5d86f09c9d"
 dependencies = [
+ "arbitrary",
  "base64 0.13.1",
  "crate-git-revision",
  "escape-bytes",

--- a/crates/contracts/core/Cargo.toml
+++ b/crates/contracts/core/Cargo.toml
@@ -6,8 +6,12 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+testutils = []
+
 [dependencies]
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { workspace = true }
+soroban-sdk = { workspace = true, features = ["testutils"] }
+derive_arbitrary = "=1.3.2"

--- a/crates/contracts/core/src/lib.rs
+++ b/crates/contracts/core/src/lib.rs
@@ -1,23 +1,191 @@
 #![no_std]
 
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Symbol,
+};
 
-pub fn init(env: Env, admin: Address) {
-    let _ = (env, admin);
+pub const DISPUTE_WINDOW_MIN_SECONDS: u64 = 60;
+pub const DISPUTE_WINDOW_MAX_SECONDS: u64 = 30 * 24 * 60 * 60;
+pub const DEFAULT_DISPUTE_WINDOW_SECONDS: u64 = 24 * 60 * 60;
+
+#[contract]
+pub struct SkillSyncContract;
+
+#[contracttype]
+#[derive(Clone)]
+enum DataKey {
+    Admin,
+    DisputeWindow,
 }
 
-pub fn ping(env: Env) -> u32 {
-    let _ = env;
-    1
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    InvalidDisputeWindow = 3,
+    Unauthorized = 4,
+}
+
+#[contractimpl]
+impl SkillSyncContract {
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic_with_error!(&env, Error::AlreadyInitialized);
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::DisputeWindow, &DEFAULT_DISPUTE_WINDOW_SECONDS);
+    }
+
+    pub fn ping(_env: Env) -> u32 {
+        1
+    }
+
+    pub fn get_dispute_window(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::DisputeWindow)
+            .unwrap_or(DEFAULT_DISPUTE_WINDOW_SECONDS)
+    }
+
+    pub fn set_dispute_window(env: Env, seconds: u64) -> Result<(), Error> {
+        let admin = read_admin(&env)?;
+        admin.require_auth();
+
+        validate_dispute_window(seconds)?;
+
+        let old = Self::get_dispute_window(env.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::DisputeWindow, &seconds);
+        env.events()
+            .publish((Symbol::new(&env, "DisputeWindowUpdated"),), (old, seconds));
+        Ok(())
+    }
+}
+
+fn read_admin(env: &Env) -> Result<Address, Error> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)
+}
+
+fn validate_dispute_window(seconds: u64) -> Result<(), Error> {
+    if !(DISPUTE_WINDOW_MIN_SECONDS..=DISPUTE_WINDOW_MAX_SECONDS).contains(&seconds) {
+        return Err(Error::InvalidDisputeWindow);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Events},
+        vec, Address, Env, IntoVal,
+    };
 
     #[test]
     fn test_ping() {
         let env = Env::default();
-        assert_eq!(ping(env), 1);
+        let contract_id = env.register_contract(None, SkillSyncContract);
+        let client = SkillSyncContractClient::new(&env, &contract_id);
+
+        assert_eq!(client.ping(), 1);
+    }
+
+    #[test]
+    fn test_get_and_set_dispute_window_persists() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, SkillSyncContract);
+        let client = SkillSyncContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.init(&admin);
+        assert_eq!(client.get_dispute_window(), DEFAULT_DISPUTE_WINDOW_SECONDS);
+
+        let updated = 120_u64;
+        client.set_dispute_window(&updated);
+        assert_eq!(client.get_dispute_window(), updated);
+    }
+
+    #[test]
+    fn test_set_dispute_window_below_min_reverts() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, SkillSyncContract);
+        let client = SkillSyncContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.init(&admin);
+        let result = client.try_set_dispute_window(&(DISPUTE_WINDOW_MIN_SECONDS - 1));
+        assert_eq!(result, Err(Ok(Error::InvalidDisputeWindow)));
+    }
+
+    #[test]
+    fn test_set_dispute_window_above_max_reverts() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, SkillSyncContract);
+        let client = SkillSyncContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.init(&admin);
+        let result = client.try_set_dispute_window(&(DISPUTE_WINDOW_MAX_SECONDS + 1));
+        assert_eq!(result, Err(Ok(Error::InvalidDisputeWindow)));
+    }
+
+    #[test]
+    fn test_set_dispute_window_requires_admin_auth() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, SkillSyncContract);
+        let client = SkillSyncContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.init(&admin);
+        client.set_dispute_window(&120_u64);
+
+        let auths = env.auths();
+        assert_eq!(auths.len(), 1);
+        assert_eq!(auths[0].0, admin);
+    }
+
+    #[test]
+    fn test_set_dispute_window_emits_event_with_old_and_new() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, SkillSyncContract);
+        let client = SkillSyncContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.init(&admin);
+
+        let old = DEFAULT_DISPUTE_WINDOW_SECONDS;
+        let new = 600_u64;
+        client.set_dispute_window(&new);
+
+        assert_eq!(
+            env.events().all(),
+            vec![
+                &env,
+                (
+                    contract_id,
+                    (Symbol::new(&env, "DisputeWindowUpdated"),).into_val(&env),
+                    (old, new).into_val(&env)
+                )
+            ]
+        );
     }
 }


### PR DESCRIPTION
Closes #48

---

## Summary
Implements issue #48 by adding configurable dispute-window management to the core Soroban contract.

## What Changed
- Added dispute-window configuration state and constants:
  - `DISPUTE_WINDOW_MIN_SECONDS = 60`
  - `DISPUTE_WINDOW_MAX_SECONDS = 30 * 24 * 60 * 60` (30 days)
  - `DEFAULT_DISPUTE_WINDOW_SECONDS = 24 * 60 * 60`
- Extended contract storage:
  - `Admin`
  - `DisputeWindow`
- Added public methods:
  - `get_dispute_window() -> u64`
  - `set_dispute_window(seconds: u64) -> Result<(), Error>`
- Restricted updates to admin:
  - `set_dispute_window` requires auth from stored admin address.
- Added validation:
  - Out-of-range values return `Error::InvalidDisputeWindow`.
- Added event emission:
  - `DisputeWindowUpdated(old, new)` emitted on successful update.

## Error Handling
- Added/used contract errors:
  - `AlreadyInitialized`
  - `NotInitialized`
  - `InvalidDisputeWindow`

## Tests Added/Updated
- `test_get_and_set_dispute_window_persists`
- `test_set_dispute_window_below_min_reverts`
- `test_set_dispute_window_above_max_reverts`
- `test_set_dispute_window_requires_admin_auth`
- `test_set_dispute_window_emits_event_with_old_and_new`

## Validation
Executed:
- `cargo test -p core -- --test-threads=1`

Result:
- 6 passed, 0 failed

## Notes
- Enabled `soroban-sdk` `testutils` for dev-dependencies in `crates/contracts/core/Cargo.toml`.
- Pinned `derive_arbitrary = 1.3.2` and updated `Cargo.lock` to resolve transitive `stellar-xdr`/`arbitrary` test build compatibility issues under current toolchain/dependency graph.
