### PR TITLE
feat: add grouped error code enums (init, auth, session, financial)

### DIFF
--- a/crates/contracts/core/src/error_codes.rs
+++ b/crates/contracts/core/src/error_codes.rs
@@ -1,0 +1,69 @@
+use soroban_sdk::contracterror;
+
+/// Errors for contract initialization failures (issue #155).
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum InitError {
+    /// Contract has already been initialized.
+    AlreadyInitialized = 100,
+    /// Contract has not been initialized yet.
+    NotInitialized = 101,
+    /// Admin address is zero or invalid.
+    InvalidAdmin = 102,
+    /// Treasury address is zero or invalid.
+    InvalidTreasury = 103,
+}
+
+/// Errors for unauthorized function calls (issue #156).
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum AuthError {
+    /// Generic unauthorized access.
+    Unauthorized = 200,
+    /// Caller is not the contract admin.
+    NotAdmin = 201,
+    /// Caller is not the session buyer.
+    NotBuyer = 202,
+    /// Caller is not the session seller.
+    NotSeller = 203,
+}
+
+/// Errors for invalid session operations (issue #157).
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum SessionError {
+    /// Session ID does not exist.
+    SessionNotFound = 300,
+    /// Session ID already exists.
+    DuplicateSessionId = 301,
+    /// Operation not allowed in the current session state.
+    InvalidSessionState = 302,
+    /// Cannot complete a session that is already completed.
+    SessionAlreadyCompleted = 303,
+    /// Cannot approve a session that is already approved.
+    SessionAlreadyApproved = 304,
+    /// Session has already been refunded.
+    SessionAlreadyRefunded = 305,
+    /// Cannot act on a session that is currently in dispute.
+    SessionInDispute = 306,
+}
+
+/// Errors for amount and fee validation (issue #158).
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum FinancialError {
+    /// Amount is zero or negative.
+    InvalidAmount = 400,
+    /// Buyer has insufficient funds.
+    InsufficientBalance = 401,
+    /// Fee exceeds the maximum allowed (1000 bps).
+    FeeTooHigh = 402,
+    /// Dispute split does not sum to the session amount.
+    InvalidSplit = 403,
+    /// Arithmetic overflow detected.
+    Overflow = 404,
+}

--- a/crates/contracts/core/src/lib.rs
+++ b/crates/contracts/core/src/lib.rs
@@ -1,5 +1,9 @@
 #![no_std]
 
+pub mod error_codes;
+
+pub use error_codes::{AuthError, FinancialError, InitError, SessionError};
+
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, token, Address, Bytes,
     Env, Symbol, Vec,


### PR DESCRIPTION
## Summary

This PR implements all 4 issues assigned to @Demilade18-git.

---

### Issue #155 — Initialization errors

```rust
pub enum InitError {
    AlreadyInitialized = 100,
    NotInitialized     = 101,
    InvalidAdmin       = 102,
    InvalidTreasury    = 103,
}
```
Closes #155

---

### Issue #156 — Authorization errors

```rust
pub enum AuthError {
    Unauthorized = 200,
    NotAdmin     = 201,
    NotBuyer     = 202,
    NotSeller    = 203,
}
```
Closes #156

---

### Issue #157 — Session validation errors

```rust
pub enum SessionError {
    SessionNotFound        = 300,
    DuplicateSessionId     = 301,
    InvalidSessionState    = 302,
    SessionAlreadyCompleted = 303,
    SessionAlreadyApproved = 304,
    SessionAlreadyRefunded = 305,
    SessionInDispute       = 306,
}
```
Closes #157

---

### Issue #158 — Financial validation errors

```rust
pub enum FinancialError {
    InvalidAmount       = 400,
    InsufficientBalance = 401,
    FeeTooHigh          = 402,
    InvalidSplit        = 403,
    Overflow            = 404,
}
```
Closes #158

---

### Files changed
- `crates/contracts/core/src/error_codes.rs` — new file with all 4 enums
- `crates/contracts/core/src/lib.rs` — added `pub mod error_codes` and re-exports

All enums use `#[contracterror]` (provides `Into<u32>`) and `#[derive(Copy, Clone, Debug, Eq, PartialEq)]`.