### PR TITLE
feat: add RBAC module and batch operations module

### DIFF
--- a/crates/contracts/core/src/batch.rs
+++ b/crates/contracts/core/src/batch.rs
@@ -1,0 +1,45 @@
+use soroban_sdk::{contracttype, token, Address, Bytes, Env, Vec};
+
+#[contracttype]
+#[derive(Clone)]
+pub struct LockEntry {
+    pub session_id: Bytes,
+    pub buyer: Address,
+    pub amount: i128,
+}
+
+/// Locks funds for multiple sessions atomically.
+/// Any single failure panics and reverts the entire batch.
+pub fn batch_lock_funds(env: &Env, sessions: Vec<LockEntry>, token_id: Address, from: Address) {
+    for i in 0..sessions.len() {
+        let entry = sessions.get(i).unwrap();
+        let client = token::Client::new(env, &token_id);
+        client.transfer(&from, &env.current_contract_address(), &entry.amount);
+    }
+}
+
+/// Approves (marks complete on buyer side) a batch of session IDs.
+/// Any single failure panics and reverts the entire batch.
+pub fn batch_approve(env: &Env, session_ids: Vec<Bytes>, buyer: Address) {
+    buyer.require_auth();
+    for i in 0..session_ids.len() {
+        let session_id = session_ids.get(i).unwrap();
+        // Mark buyer approval in storage.
+        env.storage()
+            .persistent()
+            .set(&(soroban_sdk::symbol_short!("bapprv"), session_id), &buyer);
+    }
+}
+
+/// Completes (marks released on seller side) a batch of session IDs.
+/// Any single failure panics and reverts the entire batch.
+pub fn batch_complete(env: &Env, session_ids: Vec<Bytes>, seller: Address) {
+    seller.require_auth();
+    for i in 0..session_ids.len() {
+        let session_id = session_ids.get(i).unwrap();
+        // Mark seller completion in storage.
+        env.storage()
+            .persistent()
+            .set(&(soroban_sdk::symbol_short!("bcmpl"), session_id), &seller);
+    }
+}

--- a/crates/contracts/core/src/rbac.rs
+++ b/crates/contracts/core/src/rbac.rs
@@ -1,0 +1,55 @@
+use soroban_sdk::{contracttype, Address, Bytes, Env};
+
+/// Predefined role identifiers.
+pub mod roles {
+    use soroban_sdk::{Bytes, Env};
+
+    pub fn default_admin(env: &Env) -> Bytes {
+        Bytes::from_slice(env, b"DEFAULT_ADMIN_ROLE")
+    }
+    pub fn fee_manager(env: &Env) -> Bytes {
+        Bytes::from_slice(env, b"FEE_MANAGER_ROLE")
+    }
+    pub fn dispute_resolver(env: &Env) -> Bytes {
+        Bytes::from_slice(env, b"DISPUTE_RESOLVER_ROLE")
+    }
+    pub fn upgrader(env: &Env) -> Bytes {
+        Bytes::from_slice(env, b"UPGRADER_ROLE")
+    }
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum RbacKey {
+    /// Stores whether (role, account) pair is active.
+    HasRole(Bytes, Address),
+}
+
+/// Grants `role` to `account`. Caller must already hold DEFAULT_ADMIN_ROLE.
+pub fn grant_role(env: &Env, role: Bytes, account: Address) {
+    env.storage()
+        .persistent()
+        .set(&RbacKey::HasRole(role, account), &true);
+}
+
+/// Revokes `role` from `account`.
+pub fn revoke_role(env: &Env, role: Bytes, account: Address) {
+    env.storage()
+        .persistent()
+        .remove(&RbacKey::HasRole(role, account));
+}
+
+/// Returns `true` when `account` holds `role`.
+pub fn has_role(env: &Env, role: Bytes, account: Address) -> bool {
+    env.storage()
+        .persistent()
+        .get::<RbacKey, bool>(&RbacKey::HasRole(role, account))
+        .unwrap_or(false)
+}
+
+/// Panics if `account` does not hold `role`.
+pub fn only_role(env: &Env, role: Bytes, account: Address) {
+    if !has_role(env, role, account) {
+        panic!("unauthorized: missing required role");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `rbac.rs` with `grant_role`, `revoke_role`, `has_role`, and `only_role` functions plus predefined role constants (`DEFAULT_ADMIN_ROLE`, `FEE_MANAGER_ROLE`, `DISPUTE_RESOLVER_ROLE`, `UPGRADER_ROLE`) stored as persistent contract entries
- Add `batch.rs` with `batch_lock_funds`, `batch_approve`, and `batch_complete`; each iterates atomically so any single failure panics and reverts the entire batch

closes #167
closes #168