### PR TITLE
feat: time-locked vesting module and webhook event relay

### DIFF
--- a/crates/contracts/core/src/vesting.rs
+++ b/crates/contracts/core/src/vesting.rs
@@ -1,0 +1,97 @@
+//! Time-locked vesting release for sellers.
+//!
+//! Supports linear vesting with an optional cliff period.
+//! After the cliff, the seller may claim the linearly-vested portion at any time.
+//! If the session is disputed, unvested funds return to the buyer.
+
+use soroban_sdk::{contracttype, Address, Env, Symbol, symbol_short};
+
+const KEY_VESTING: Symbol = symbol_short!("vesting");
+
+/// Vesting schedule attached to a session.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct VestingSchedule {
+    pub session_id: soroban_sdk::Bytes,
+    pub seller: Address,
+    pub buyer: Address,
+    pub total_amount: i128,
+    /// Ledger number after which vesting begins.
+    pub cliff_ledger: u64,
+    /// Total ledgers over which the full amount vests linearly.
+    pub vesting_duration: u64,
+    /// Ledger when this schedule was created.
+    pub start_ledger: u64,
+    /// Amount already claimed by the seller.
+    pub claimed_amount: i128,
+    pub is_disputed: bool,
+}
+
+fn vesting_key(env: &Env, session_id: &soroban_sdk::Bytes) -> (Symbol, soroban_sdk::Bytes) {
+    (KEY_VESTING, session_id.clone())
+}
+
+/// Lock funds with a vesting schedule for `session_id`.
+pub fn lock_funds_with_vesting(
+    env: &Env,
+    session_id: soroban_sdk::Bytes,
+    seller: Address,
+    buyer: Address,
+    amount: i128,
+    cliff_ledgers: u64,
+    vesting_duration: u64,
+) {
+    let schedule = VestingSchedule {
+        session_id: session_id.clone(),
+        seller,
+        buyer,
+        total_amount: amount,
+        cliff_ledger: env.ledger().sequence() as u64 + cliff_ledgers,
+        vesting_duration,
+        start_ledger: env.ledger().sequence() as u64,
+        claimed_amount: 0,
+        is_disputed: false,
+    };
+    env.storage().persistent().set(&vesting_key(env, &session_id), &schedule);
+}
+
+/// Returns how much the seller can currently claim.
+pub fn claimable_amount(env: &Env, schedule: &VestingSchedule) -> i128 {
+    let current = env.ledger().sequence() as u64;
+    if current < schedule.cliff_ledger || schedule.is_disputed {
+        return 0;
+    }
+    let elapsed = current.saturating_sub(schedule.start_ledger);
+    let vested = if elapsed >= schedule.vesting_duration {
+        schedule.total_amount
+    } else {
+        (schedule.total_amount as u128 * elapsed as u128 / schedule.vesting_duration as u128) as i128
+    };
+    (vested - schedule.claimed_amount).max(0)
+}
+
+/// Seller claims vested amount. Returns the amount to transfer.
+pub fn claim_vested(env: &Env, session_id: soroban_sdk::Bytes, seller: &Address) -> i128 {
+    seller.require_auth();
+    let key = vesting_key(env, &session_id);
+    let mut schedule: VestingSchedule = env.storage().persistent().get(&key).expect("no vesting schedule");
+    assert!(&schedule.seller == seller, "not the seller");
+    let amount = claimable_amount(env, &schedule);
+    assert!(amount > 0, "nothing to claim");
+    schedule.claimed_amount += amount;
+    env.storage().persistent().set(&key, &schedule);
+    amount
+}
+
+/// Mark a session as disputed — unvested funds become returnable to buyer.
+pub fn mark_disputed(env: &Env, session_id: soroban_sdk::Bytes) {
+    let key = vesting_key(env, &session_id);
+    let mut schedule: VestingSchedule = env.storage().persistent().get(&key).expect("no vesting schedule");
+    schedule.is_disputed = true;
+    env.storage().persistent().set(&key, &schedule);
+}
+
+/// Returns unvested amount owed back to buyer after dispute.
+pub fn unvested_amount(schedule: &VestingSchedule) -> i128 {
+    (schedule.total_amount - schedule.claimed_amount).max(0)
+}

--- a/crates/contracts/core/src/webhook.rs
+++ b/crates/contracts/core/src/webhook.rs
@@ -1,0 +1,67 @@
+//! Webhook / event relay configuration.
+//!
+//! The admin registers an off-chain relay URL. The contract emits structured
+//! events that an indexer or relayer can pick up and forward as HTTP webhooks.
+
+use soroban_sdk::{contracttype, Address, Env, String, Symbol, symbol_short};
+
+const KEY_WEBHOOK_URL: Symbol = symbol_short!("wh_url");
+const KEY_WEBHOOK_ENABLED: Symbol = symbol_short!("wh_on");
+
+/// Webhook event payload stored in contract events.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct WebhookPayload {
+    pub session_id: soroban_sdk::Bytes,
+    pub event_type: String,
+    pub timestamp: u64,
+    pub data: String,
+}
+
+/// Admin-only: set the webhook relay URL.
+pub fn set_webhook(env: &Env, admin: &Address, url: String) {
+    admin.require_auth();
+    env.storage().instance().set(&KEY_WEBHOOK_URL, &url);
+    env.storage().instance().set(&KEY_WEBHOOK_ENABLED, &true);
+}
+
+/// Admin-only: disable webhook relay.
+pub fn disable_webhook(env: &Env, admin: &Address) {
+    admin.require_auth();
+    env.storage().instance().set(&KEY_WEBHOOK_ENABLED, &false);
+}
+
+/// Returns the configured webhook URL, if any.
+pub fn get_webhook_url(env: &Env) -> Option<String> {
+    env.storage().instance().get(&KEY_WEBHOOK_URL)
+}
+
+/// Returns whether webhook relay is currently enabled.
+pub fn is_webhook_enabled(env: &Env) -> bool {
+    env.storage().instance().get(&KEY_WEBHOOK_ENABLED).unwrap_or(false)
+}
+
+/// Emit a structured webhook event for off-chain relay.
+///
+/// Call this from contract entry points after significant state changes.
+/// An indexer reads these events and forwards them to the registered URL.
+pub fn emit_webhook_event(
+    env: &Env,
+    session_id: soroban_sdk::Bytes,
+    event_type: String,
+    data: String,
+) {
+    if !is_webhook_enabled(env) {
+        return;
+    }
+    let payload = WebhookPayload {
+        session_id,
+        event_type,
+        timestamp: env.ledger().timestamp(),
+        data,
+    };
+    env.events().publish(
+        (symbol_short!("webhook"), symbol_short!("relay")),
+        payload,
+    );
+}


### PR DESCRIPTION
Adds two new Soroban contract modules.

### Time-locked Release Module (vesting.rs)
- `lock_funds_with_vesting` — stores a `VestingSchedule` with cliff ledger, duration, seller/buyer addresses, and total amount
- `claimable_amount` — computes linearly vested portion: `total * (elapsed / duration)` after cliff, zero before cliff or during dispute
- `claim_vested` — seller auth-gated claim; increments `claimed_amount` and returns the transfer amount
- `mark_disputed` — flips `is_disputed` flag, blocking further seller claims
- `unvested_amount` — returns remaining balance owed back to buyer on dispute

### Webhook / Event Relay Module (webhook.rs)
- `set_webhook` / `disable_webhook` — admin-gated URL registration in instance storage
- `get_webhook_url` / `is_webhook_enabled` — read helpers
- `emit_webhook_event` — publishes a structured `WebhookPayload` (session ID, event type, timestamp, data) via `env.events()` for off-chain indexer pickup; no-ops when webhook is disabled

closes #165
closes #166